### PR TITLE
Loosen gem dependencies

### DIFF
--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "activerecord", ">= 3.2.6", "< 5"
-  s.add_dependency "actionmailer", ">= 3.2.6", "< 5"
-  s.add_dependency "devise", "~> 3.2.0"
+  s.add_dependency "activerecord"
+  s.add_dependency "actionmailer"
+  s.add_dependency "devise"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
* We're working on upgrading our main app that
  depends on this gem to Rail 4.1. Removing the
  specific versioning for the gems this gem 
  depends on

[#153707648]